### PR TITLE
Change peerDependencies to per valid for all Angular 7.2.x releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
 		"qrcodejs2": "0.0.2"
 	},
 	"peerDependencies": {
-		"@angular/common": ">= 5.0.0 <= 7.2.0",
-		"@angular/core": ">= 5.0.0 <= 7.2.0"
+		"@angular/common": ">= 5.0.0 <= 7.2.99",
+		"@angular/core": ">= 5.0.0 <= 7.2.99"
 	},
 	"devDependencies": {
 		"@angular/cli": "^7.1.1",


### PR DESCRIPTION
The peerDependencies have been changed so that we don't need a new release for every upcoming Angular release on the 7.2 line.