### PR TITLE
Update peerDepndencies to allow all Angular between 5 and 8.0 (incl)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "qrcodejs2": "0.0.2"
   },
   "peerDependencies": {
-    "@angular/common": ">= 5.0.0 < 7.3.0",
-    "@angular/core": ">= 5.0.0 < 7.3.0"
+    "@angular/common": ">= 5.0.0 < 8.1.0",
+    "@angular/core": ">= 5.0.0 < 8.1.0"
   },
   "devDependencies": {
     "@angular/cli": "^7.2.3",


### PR DESCRIPTION
Current release has been tested with Angular 8 and it works w/o issues. 
This change is just adjusting the peerDependencies setting to include Angular 8.0.x