### PR TITLE
feat: add event emitter to qrcode url

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,8 @@ export class QRCodeComponent {
 <a [href]="qrCodeDownloadLink" download="qrcode">Download</a>
 ```
 The file format obtained by `qrCodeURL` depends directly on the 
-elementType of `<qrcode>`. If it is canvas, url or img, the return 
-will be an image in `.png` format. If it is svg, the return will be 
-a file of `svg` format.
+elementType of `<qrcode>`.  If it's either canvas, url or image, 
+it returns an image as `.png`, if it's svg, returns a `.svg` file.
 
 
 ## Available Parameters

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ export class QRCodeComponent {
 | title                | String  | null        | HTML title attribute (supported by canvas, img, url)           |
 | version              | Number  | (auto)      | 1-40                                                           |
 | width                | Number  | 10          | Height/Width (any value)                                       |
-
+| qrCodeURL            | EventEmitter\<SafeUrl\> | | Output the QRCode URL
 ## QR Code capacity
 
 Depending on the amount of data of the **qrdata** to encode, a minimum **width** is required.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,35 @@ export class QRCodeComponent {
 <qrcode [qrdata]="myAngularxQrCode" [width]="256" [errorCorrectionLevel]="'M'"></qrcode>
 ```
 
+### Getting the QRCode URL
+To download the QRCode, we have to use the `qrCodeURL` attribute
+of the `<qrcode>` which returns a sanitized URL representing the 
+location of the QRCode.
+```
+// File: example.ts
+export class QRCodeComponent {
+  public myAngularxQrCode: string = "";
+  public qrCodeDownloadLink: SafeUrl = "";
+
+  constructor () {
+    this.myAngularxQrCode = 'Your QR code data string';
+  }
+  
+  onChangeURL(url: SafeUrl) {
+    this.qrCodeDownloadLink = url;
+  }
+}
+
+// File: example.html
+<qrcode (qrCodeURL)="onChangeURL($event)" [qrdata]="myAngularxQrCode" [width]="256" [errorCorrectionLevel]="'M'"></qrcode>
+<a [href]="qrCodeDownloadLink" download="qrcode">Download</a>
+```
+The file format obtained by `qrCodeURL` depends directly on the 
+elementType of `<qrcode>`. If it is canvas, url or img, the return 
+will be an image in `.png` format. If it is svg, the return will be 
+a file of `svg` format.
+
+
 ## Available Parameters
 
 | Attribute            | Type    | Default     | Description                                                    |

--- a/projects/angularx-qrcode/README.md
+++ b/projects/angularx-qrcode/README.md
@@ -136,7 +136,7 @@ export class QRCodeComponent {
 | title                | String  | null        | HTML title attribute (supported by canvas, img, url)           |
 | version              | Number  | (auto)      | 1-40                                                           |
 | width                | Number  | 10          | Height/Width (any value)                                       |
-
+| qrCodeURL            | EventEmitter\<SafeUrl\> | | Output the QRCode URL
 ## QR Code capacity
 
 Depending on the amount of data of the **qrdata** to encode, a minimum **width** is required.


### PR DESCRIPTION
### Feature
I added an `EventEmitter` that outputs the SafeUrl of the QRCode to the parent component of the `<qrcode>` component.

### Details
- The emission of the URL is done by the `emitQRCodeURL` method
- When ElementType is canvas or url or img the EventEmitter returns png.
- When the ElementType is svg the EventEmitter returns svg.


### Example of use
```Typescript
@Component({
    selector: "app-example",
    template: `
         <qrcode 
            colorLight="#FAF9F8" 
            [qrdata]="text" 
            [width]="300" 
            [errorCorrectionLevel]="'M'"
            (qrCodeURL)="onChangeURL($event)"
        ></qrcode>

        <a [href]="qrCodeSrc" download="qrcode">Download</a>
    `
})
export class ExampleComponent {
    qrCodeSrc!: SafeUrl;

    onChangeURL(url: SafeUrl) {
        this.qrCodeSrc = url;
    }

}  
```

**PS**: I apologize for any typos, I'm using google translator.