### PR TITLE
add event emitter for when qrcode has been clicked

### DIFF
--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -23,7 +23,7 @@ import {
 @Component({
   selector: "qrcode",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `<div #qrcElement [class]="cssClass"></div>`,
+  template: `<div (click)="qrCodeClicked.emit($event)" #qrcElement [class]="cssClass"></div>`,
 })
 export class QRCodeComponent implements OnChanges {
   @Input() public allowEmptyString = false
@@ -48,6 +48,7 @@ export class QRCodeComponent implements OnChanges {
   @Input() public title?: string
 
   @Output() qrCodeURL = new EventEmitter<SafeUrl>()
+  @Output() qrCodeClicked = new EventEmitter<Event>();
 
   @ViewChild("qrcElement", { static: true }) public qrcElement!: ElementRef
 

--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -48,7 +48,7 @@ export class QRCodeComponent implements OnChanges {
   @Input() public title?: string
 
   @Output() qrCodeURL = new EventEmitter<SafeUrl>()
-  @Output() qrCodeClicked = new EventEmitter<Event>();
+  @Output() qrCodeClicked = new EventEmitter<Event>()
 
   @ViewChild("qrcElement", { static: true }) public qrcElement!: ElementRef
 

--- a/projects/demo-app/src/app/app.component.html
+++ b/projects/demo-app/src/app/app.component.html
@@ -42,8 +42,11 @@
               [scale]="scale" [width]="width" [allowEmptyString]="true" [className]="cssClass" [colorDark]="colorDark"
               [colorLight]="colorLight" [margin]="margin" [alt]="alt" [ariaLabel]="ariaLabel" [title]="title"
               [imageSrc]="imageSrc" [imageHeight]="imageHeight" [imageWidth]="imageWidth"
-              (qrCodeURL)="onChangeURL($event)"></qrcode>
+              (qrCodeClicked)="onQrCodeClicked()"
+              (qrCodeURL)="onChangeURL($event)">
+            </qrcode>
           </div>
+          <div *ngIf="qrCodeClicked" class="downloadButton">QR code has been clicked!</div>
           <div class="downloadButton">
             <button *ngIf="this.elementType !== 'svg'" mat-raised-button color="primary"
               (click)="saveAsImage(parent)">Download QR Code Image</button>

--- a/projects/demo-app/src/app/app.component.ts
+++ b/projects/demo-app/src/app/app.component.ts
@@ -28,6 +28,7 @@ export class AppComponent {
     imageWidth: 75,
     margin: 4,
     qrdata: "https://github.com/Cordobo/angularx-qrcode",
+    qrCodeClicked: false,
     scale: 1,
     version: undefined,
     title: "A custom title attribute",
@@ -51,6 +52,7 @@ export class AppComponent {
   public imageWidth?: number
   public margin: number
   public qrdata: string
+  public qrCodeClicked: boolean
   public scale: number
   public title: string
   public width: number
@@ -89,6 +91,7 @@ export class AppComponent {
     this.imageWidth = this.showImage ? this.data_model.imageWidth : undefined
     this.margin = this.data_model.margin
     this.qrdata = this.data_model.qrdata
+    this.qrCodeClicked = this.data_model.qrCodeClicked
     this.scale = this.data_model.scale
     this.title = this.data_model.title
     this.width = this.data_model.width
@@ -181,6 +184,10 @@ export class AppComponent {
   // Re-enable, when a method to download images has been implemented
   onChangeURL(url: SafeUrl) {
     this.qrCodeSrc = url
+  }
+
+  onQrCodeClicked() {
+    this.qrCodeClicked = true
   }
 
   saveAsImage(parent: any) {


### PR DESCRIPTION
It would be nice if the element in which the QR code lives has a click event emitter so you know when the element has been clicked.

At the moment if i want to add an eventListener myself i have to access the `qrcElement` on `QRCodeComponent` and put an event listener on that element and also remove it when the component gets destroyed. It gets the job done, but could be simpler ;-)



