### PR TITLE
use the previously unused type.

### DIFF
--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -11,7 +11,6 @@ import {
 } from "@angular/core"
 import { DomSanitizer, SafeUrl } from "@angular/platform-browser"
 import {
-  QRCodeErrorCorrectionLevel,
   QRCodeRenderersOptions,
   QRCodeToDataURLOptions,
   QRCodeToStringOptions,
@@ -19,7 +18,13 @@ import {
   toDataURL,
   toString,
 } from "qrcode"
-import { QRCodeVersion, QRCodeElementType, FixMeLater } from "./types"
+import {
+  QRCodeErrorCorrectionLevel,
+  QRCodeConfigType,
+  QRCodeElementType,
+  QRCodeVersion,
+  FixMeLater,
+} from "./types"
 
 @Component({
   selector: "qrcode",
@@ -174,7 +179,7 @@ export class QRCodeComponent implements OnChanges {
         this.qrdata = " "
       }
 
-      const config = {
+      const config: QRCodeConfigType = {
         color: {
           dark: this.colorDark,
           light: this.colorLight,

--- a/projects/angularx-qrcode/src/lib/types.ts
+++ b/projects/angularx-qrcode/src/lib/types.ts
@@ -16,7 +16,7 @@ export interface QRCodeConfigType {
   errorCorrectionLevel: QRCodeErrorCorrectionLevel
   margin: number
   scale: number
-  version: QRCodeVersion | undefined
+  version?: QRCodeVersion
   width: number
 }
 


### PR DESCRIPTION
A warning message was signaled regarding the use of 'sample' in Node.js.
However, this library's usage of 'QRCodeErrorCorrectionLevel' depends on 'qrcode', not 'angularx-qrcode'. 
Therefore, I have made adjustments in this commit.

# using sample code warning
![pasted-2024 02 21-13 25 25](https://github.com/Cordobo/angularx-qrcode/assets/30658134/9ba13d89-9700-43ef-88f2-196fb6248fc9)


> Type string is not assignable to type QRCodeErrorCorrectionLeve


```
# ASIS
import {QRCodeErrorCorrectionLevel} from "qrcode";

# TOBE
import {QRCodeErrorCorrectionLevel} from "angularx-qrcode";


errorCorrectionLevel: QRCodeErrorCorrectionLevel = 'M';
```