### PR TITLE
fix #260: allow download canvas with embedded images from other origins

### DIFF
--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -227,6 +227,7 @@ export class QRCodeComponent implements OnChanges {
                 )
 
                 if (centerImageSrc !== this.centerImage.src) {
+                  this.centerImage.crossOrigin = "anonymous"
                   this.centerImage.src = centerImageSrc
                 }
 


### PR DESCRIPTION
If an external image (e.g., your logo) is added to the canvas, it must be handled with proper CORS settings (crossOrigin = "anonymous") before the image source is set. 

If the crossOrigin setting is missing, the browser does not allow to download canvas from other origins!

This fixes #260 
