### PR TITLE
feat(height, width): accept string

### DIFF
--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -40,8 +40,8 @@ export class QRCodeComponent implements OnChanges {
   @Input()
   public errorCorrectionLevel: QRCodeErrorCorrectionLevel = "M"
   @Input() public imageSrc?: string
-  @Input() public imageHeight?: number
-  @Input() public imageWidth?: number
+  @Input() public imageHeight?: number | string
+  @Input() public imageWidth?: number | string
   @Input() public margin = 4
   @Input() public qrdata = ""
   @Input() public scale = 4
@@ -195,8 +195,8 @@ export class QRCodeComponent implements OnChanges {
       }
 
       const centerImageSrc = this.imageSrc
-      const centerImageHeight = this.imageHeight || 40
-      const centerImageWidth = this.imageWidth || 40
+      const centerImageHeight = this.imageHeight ? +this.imageHeight : 40
+      const centerImageWidth = this.imageWidth ? +this.imageWidth : 40
 
       switch (this.elementType) {
         case "canvas": {


### PR DESCRIPTION
## Description
Closes: https://github.com/Cordobo/angularx-qrcode/issues/272#issuecomment-2907004275

## Note
User will be able to do `imageHeight="200px"` which is false. 

As the exemple are clear enough, I wouldn't care, but if wished, I could add an additional 

```
if(imageHeight && isNan(imageHeight) console.warn('imageHeight expect a number')
```

Or something similar