### PR TITLE
ref(angularx-qrcode.component.ts): prevent qr regeneration on accessi…

### DIFF
--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -72,7 +72,7 @@ export class QRCodeComponent implements OnChanges {
     }
 
     if (this.hasAccessibilityChanges(changes)) {
-      this.setAccessibilityAttributes() // Update existing element attributes
+      this.setAccessibilityAttributes()
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/Cordobo/angularx-qrcode/issues/279

ngOnchanges  checks input changes and only regenerates the qr if inputs that effect QR generation has changed.