### PR TITLE
feat: allow string width input

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ it returns an image as `.png`, if it's svg, returns a `.svg` file.
 | scale                | Number                  | 4           | Scale factor. A value of 1 means 1px per modules (black dots). |
 | title                | String                  | null        | HTML title attribute (supported by canvas, img, url)           |
 | version              | Number                  | (auto)      | 1-40                                                           |
-| width                | Number                  | 10          | Height/Width (any value)                                       |
+| width                | Number \| String        | 10          | Height/Width (any value, e.g. 256 or '100%')                   |
 
 ## QR Code capacity
 

--- a/projects/angularx-qrcode/README.md
+++ b/projects/angularx-qrcode/README.md
@@ -231,7 +231,7 @@ it returns an image as `.png`, if it's svg, returns a `.svg` file.
 | scale                | Number                  | 4           | Scale factor. A value of 1 means 1px per modules (black dots). |
 | title                | String                  | null        | HTML title attribute (supported by canvas, img, url)           |
 | version              | Number                  | (auto)      | 1-40                                                           |
-| width                | Number                  | 10          | Height/Width (any value)                                       |
+| width                | Number \| String        | 10          | Height/Width (any value, e.g. 256 or '100%')                   |
 
 ## QR Code capacity
 

--- a/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
+++ b/projects/angularx-qrcode/src/lib/angularx-qrcode.component.ts
@@ -48,7 +48,7 @@ export class QRCodeComponent implements OnChanges {
   @Input() public qrdata = ''
   @Input() public scale = 4
   @Input() public version?: QRCodeVersion
-  @Input() public width = 10
+  @Input() public width: number | string = 10
 
   // Accessibility features introduced in 13.0.4+
   @Input() public alt?: string
@@ -153,6 +153,7 @@ export class QRCodeComponent implements OnChanges {
         this.qrdata = ' '
       }
 
+      const numericWidth = Number(this.width)
       const config: QRCodeConfigType = {
         color: {
           dark: this.colorDark,
@@ -162,7 +163,7 @@ export class QRCodeComponent implements OnChanges {
         margin: this.margin,
         scale: this.scale,
         version: this.version,
-        width: this.width,
+        width: Number.isFinite(numericWidth) ? numericWidth : undefined,
       }
 
       const centerImageSrc = this.imageSrc

--- a/projects/angularx-qrcode/src/lib/types.ts
+++ b/projects/angularx-qrcode/src/lib/types.ts
@@ -17,7 +17,7 @@ export interface QRCodeConfigType {
   margin: number
   scale: number
   version?: QRCodeVersion
-  width: number
+  width?: number
 }
 
 export type QRCodeElementType = 'url' | 'img' | 'canvas' | 'svg'


### PR DESCRIPTION
﻿## Summary
- widen the `width` input type to `number | string` so strict Angular templates accept values such as `width="100%"`
- keep the QRCode renderer config numeric by passing `undefined` for non-numeric widths
- update README parameter docs for the new accepted type

## Testing
- npm run lint -- --fix=false
- npm run ci:build:lib
- git diff --check

Fixes #324
